### PR TITLE
Fixed: complex example typo

### DIFF
--- a/examples/complex/index.js
+++ b/examples/complex/index.js
@@ -35,7 +35,7 @@ app.engine('.jsx', engine);
 // set the view directory
 app.set('views', __dirname + '/public/views');
 
-// set js as the view engine
+// set jsx as the view engine
 app.set('view engine', 'jsx');
 
 // finally, set the custom view

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "git@github.com:paypal/react-engine.git"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com"
+  },
   "peerDependencies": {
     "react": "~0.12",
     "react-router": "~0.12",


### PR DESCRIPTION
Changed: `js` => `jsx`