### PR TITLE
Fixing issue with example

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -19,7 +19,7 @@
 require('node-jsx').install();
 
 var express = require('express');
-var renderer = require('../../index');
+var renderer = require('react-engine');
 
 var app = express();
 

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -9,6 +9,9 @@
     "browserify": "^9.0.4",
     "express": "^4.12.3",
     "node-jsx": "^0.12.4",
+    "react": "^0.12.2",
+    "react-engine": "^1.3.0",
+    "react-router": "^0.12.4",
     "reactify": "^1.1.0",
     "require-globify": "^1.1.0"
   }

--- a/examples/simple/public/index.js
+++ b/examples/simple/public/index.js
@@ -15,8 +15,8 @@
 
 'use strict';
 
-var Client = require('../../../lib/client');
-var React = require('../../../node_modules/react/react');
+var Client = require('react-engine').client;
+var React = require('react');
 
 // Include all view files. Browerify doesn't do
 // this automatically as it can only operate on

--- a/examples/simple/public/views/index.jsx
+++ b/examples/simple/public/views/index.jsx
@@ -16,7 +16,7 @@
 'use strict';
 
 var Layout = require('./layout.jsx');
-var React = require('../../../../node_modules/react/react');
+var React = require('react');
 
 module.exports = React.createClass({
 

--- a/examples/simple/public/views/layout.jsx
+++ b/examples/simple/public/views/layout.jsx
@@ -16,7 +16,6 @@
 'use strict';
 
 var React = require('react');
-var React = require('../../../../node_modules/react/react');
 
 module.exports = React.createClass({
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "debug": "^2.1.3",
     "glob": "^5.0.3",
+    "parent-require": "^1.0.0",
     "lodash-node": "^3.3.1"
   },
   "devDependencies": {
@@ -32,7 +33,6 @@
     "jscs": "^1.11.3",
     "jsdom": "^4.1.0",
     "jshint": "^2.6.3",
-    "parent-require": "^1.0.0",
     "rewire": "^2.3.1",
     "tap-spec": "^3.0.0",
     "tape": "^3.5.0"


### PR DESCRIPTION
Fixed the issues with dependency loading in the example. 

Also, the parent-require module is a dependency not dev dependency. Because of this, when you are doing npm install react-engine, the module is not getting automatically installed