### PR TITLE
removing the passing of dependencies as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ var client = require('react-engine').client;
 
 // boot options
 var options = {
-    react: require('react'),
-    router: require('react-router'),
     routes: <PATH_TO_REACT-ROUTER_ROUTES>,
     // supply a function that can be called to resolve the file that was rendered
     viewResolver: function(viewName) {

--- a/examples/complex/public/index.js
+++ b/examples/complex/public/index.js
@@ -17,8 +17,6 @@
 
 var Routes = require('./routes.jsx');
 var Client = require('react-engine').client;
-var React = require('react');
-var Router = require('react-router');
 
 // Include all view files. Browerify doesn't do
 // this automatically as it can only operate on
@@ -27,8 +25,6 @@ require('./views/**/*.jsx', {glob: true});
 
 // boot options
 var options = {
-  react: React,
-  router: Router,
   routes: Routes,
 
   // supply a function that can be called

--- a/examples/simple/public/index.js
+++ b/examples/simple/public/index.js
@@ -16,7 +16,6 @@
 'use strict';
 
 var Client = require('react-engine').client;
-var React = require('react');
 
 // Include all view files. Browerify doesn't do
 // this automatically as it can only operate on
@@ -25,8 +24,6 @@ require('./views/**/*.jsx', {glob: true});
 
 // boot options
 var options = {
-  react: React,
-
   // supply a function that can be called
   // to resolve the file that was rendered.
   viewResolver: function(viewName) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,8 @@
 'use strict';
 
 var Config = require('./config');
-
+var React = require('react');
+var Router = require('react-router');
 // declaring like this helps in unit test
 // dependency injection using `rewire` module
 var _window;
@@ -29,8 +30,6 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 // the client side boot function
 exports.boot = function boot(options, callback) {
 
-  var React = options.react;
-  var Router = options.router;
   var Routes = options.routes;
   var viewResolver = options.viewResolver;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-engine",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "a composite render engine for express apps to render both plain react views and react-router views",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Do we need to pass react and react-router as option when it can be directly required?

If this is for giving the option to the user to change the routing module, then, the functions also should be configurable, right?

Also, since react-router is a dependency of this library,I guess it can be used directly.I don't see any advantage by passing like this.

Please correct me if I am wrong