### PR TITLE
express latest view fixes paypal/react-engine#52

### DIFF
--- a/lib/expressView.js
+++ b/lib/expressView.js
@@ -20,7 +20,44 @@ var format = require('util').format;
 var inherit = require('util').inherits;
 var debug = require('debug')(require('../package').name);
 
-var View = util.safeRequire('express/lib/view');
+var ExpressView = util.safeRequire('express/lib/view');
+
+function View(name, options) {
+  var opts = options || {};
+
+  this.defaultEngine = opts.defaultEngine;
+  //this.ext = extname(name);
+  this.name = name;
+  this.root = opts.root;
+
+  if (!this.ext && !this.defaultEngine) {
+    throw new Error('No default engine was specified and no extension was provided.');
+  }
+
+  var fileName = name;
+
+  if (!this.ext) {
+    // get extension from default engine name
+    this.ext = this.defaultEngine[0] !== '.'
+      ? '.' + this.defaultEngine
+      : this.defaultEngine;
+
+    fileName += this.ext;
+  }
+
+  if (!opts.engines[this.ext]) {
+    // load engine
+    opts.engines[this.ext] = require(this.ext.substr(1)).__express;
+  }
+
+  // store loaded engine
+  this.engine = opts.engines[this.ext];
+
+  // lookup path
+  this.path = this.lookup(fileName);
+}
+
+View.prototype = Object.create(ExpressView.prototype);
 
 function ReactEngineView(name, options) {
   debug(format('ReactEngineView :constructor: name: %s and options: %j',


### PR DESCRIPTION
Copied the latest View from express 4.13.1. The only difference between this View and Expresses is that it ignores the extension of the passed in name function.  I put in a [request to express to have a global option to suppress extension names here](https://github.com/strongloop/express/issues/2708#issuecomment-122002655).