### PR TITLE
Feature/updating to babel

### DIFF
--- a/examples/complex/index.js
+++ b/examples/complex/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require("babel/register")({});
+require('babel/register');
 
 var path = require('path');
 var express = require('express');
@@ -26,7 +26,7 @@ var app = express();
 
 // create the view engine with `react-engine`
 var engine = renderer.server.create({
-  reactRoutes: path.join(__dirname + '/public/routes.jsx')
+  routesFilePath: path.join(__dirname + '/public/routes.jsx')
 });
 
 // set the engine

--- a/examples/complex/index.js
+++ b/examples/complex/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require('node-jsx').install();
+require("babel/register")({});
 
 var path = require('path');
 var express = require('express');

--- a/examples/complex/index.js
+++ b/examples/complex/index.js
@@ -26,7 +26,7 @@ var app = express();
 
 // create the view engine with `react-engine`
 var engine = renderer.server.create({
-  routesFilePath: path.join(__dirname + '/public/routes.jsx')
+  reactRoutes: path.join(__dirname + '/public/routes.jsx')
 });
 
 // set the engine

--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -6,9 +6,9 @@
     "browserify": "browserify -t reactify -t require-globify public/index.js -o public/bundle.js"
   },
   "dependencies": {
+    "babel": "^5.8.23",
     "browserify": "^9.0.4",
     "express": "^4.12.3",
-    "node-jsx": "^0.12.4",
     "react": "^0.12.2",
     "react-engine": "^1.3.0",
     "react-router": "^0.12.4",

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require('node-jsx').install();
+require("babel/register")({});
 
 var express = require('express');
 var renderer = require('react-engine');

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require("babel/register")({});
+require('babel/register')({});
 
 var express = require('express');
 var renderer = require('react-engine');

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -6,9 +6,9 @@
     "browserify": "browserify -t reactify -t require-globify public/index.js -o public/bundle.js"
   },
   "dependencies": {
+    "babel": "^5.8.23",
     "browserify": "^9.0.4",
     "express": "^4.12.3",
-    "node-jsx": "^0.12.4",
     "react": "^0.12.2",
     "react-engine": "^1.3.0",
     "react-router": "^0.12.4",

--- a/examples/webpack/index.js
+++ b/examples/webpack/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require("babel/register")({});
+require('babel/register')({});
 
 var path = require('path');
 var express = require('express');

--- a/examples/webpack/index.js
+++ b/examples/webpack/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // make `.jsx` file requirable by node
-require('node-jsx').install();
+require("babel/register")({});
 
 var path = require('path');
 var express = require('express');

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -7,10 +7,10 @@
     "brow": "webpack -t reactify -t require-globify public/index.js -o public/bundle.js"
   },
   "dependencies": {
+    "babel": "^5.8.23",
     "express": "^4.12.3",
     "json-loader": "^0.5.2",
     "jsx-loader": "^0.13.2",
-    "node-jsx": "^0.12.4",
     "node-libs-browser": "^0.5.2",
     "react-engine": "^1.3.0",
     "webpack": "^1.10.0"


### PR DESCRIPTION
Updating the React Engine samples to use Babel instead of Node-JSX since Node-JSX was deprecated in favor of Babel. 