### PR TITLE
make the clearRequireCacheInDir platform windows friendly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,6 +19,7 @@ var _require;
 var glob = require('glob');
 var format = require('util').format;
 var debug = require('debug')('reactrenderer');
+var path = require('path')
 
 function clearRequireCache(file) {
   delete require.cache[file];
@@ -37,7 +38,7 @@ function clearRequireCacheInDir(dir, extension) {
   var files = glob.sync('**/*.' + extension, options);
 
   files.map(function(file) {
-    clearRequireCache(dir + '/' + file);
+    clearRequireCache(dir + path.sep + (file.split(/\\|\//g).join(path.sep)));
   });
 }
 


### PR DESCRIPTION
Uses path.sep with a replace to make clearing the require cache work on windows.