### PR TITLE
Escapse script end tag in data at server and unescape it at client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -33,7 +33,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 }
 
 var _unescapeScript = function(data) {
-  try{
+  try {
     var target = JSON.stringify(data);
     return JSON.parse(target.replace(/<\/_escaped_script/gm, '</script'));
   } catch (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -32,10 +32,20 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   _document = document;
 }
 
+var _unescapeScript = function(data) {
+  try{
+    var target = JSON.stringify(data);
+    return JSON.parse(target.replace(/<\/_escaped_script/gm, '</script'));
+  } catch (err) {
+    console.log(err);
+    return {};
+  }
+}
+
 // returns the data/state that was
 // injected by server during rendering
 exports.data = function data() {
-  return _window[Config.client.variableName];
+  return _unescapeScript(_window[Config.client.variableName]);
 };
 
 // the client side boot function

--- a/lib/server.js
+++ b/lib/server.js
@@ -112,6 +112,7 @@ exports.create = function create(createOptions) {
       html += ReactDOMServer.renderToString(component);
 
       // state (script) injection
+      var safeData = util.safeSciptTag(JSON.stringify(data));
       var script = format(TEMPLATE, Config.client.markupId, JSON.stringify(data));
       if (createOptions.docType === '') {
         // if the `docType` is empty, the user did not want to add a docType to the rendered component,

--- a/lib/server.js
+++ b/lib/server.js
@@ -113,7 +113,7 @@ exports.create = function create(createOptions) {
 
       // state (script) injection
       var safeData = util.safeSciptTag(JSON.stringify(data));
-      var script = format(TEMPLATE, Config.client.markupId, JSON.stringify(data));
+      var script = format(TEMPLATE, Config.client.markupId, safeData);
       if (createOptions.docType === '') {
         // if the `docType` is empty, the user did not want to add a docType to the rendered component,
         // which means they might not be rendering a full page with `html` and `body` tags

--- a/lib/util.js
+++ b/lib/util.js
@@ -68,6 +68,14 @@ function safeRequire(name) {
   return module;
 }
 
+// workaround for escaping `<script>` tag in data.
+// https://github.com/paypal/react-engine/issues/15
+var safeSciptTag = function(data) {
+  var replacer = '_escaped_script';
+  return data.replace(/<\/script/gm, '</' + replacer);
+};
+
 exports.safeRequire = safeRequire;
 exports.clearRequireCache = clearRequireCache;
 exports.clearRequireCacheInDir = clearRequireCacheInDir;
+exports.safeSciptTag = safeSciptTag;


### PR DESCRIPTION
To avoid the problem described in https://github.com/paypal/react-engine/issues/15, escapse the script end tag `</script>` in data at server and recover it at client.