### PR TITLE
Use path instead of pathname to ensure querystring is not stripped

### DIFF
--- a/lib/expressView.js
+++ b/lib/expressView.js
@@ -32,7 +32,7 @@ function ReactEngineView(name, options) {
   this.useRouter = (name[0] === '/');
 
   if (this.useRouter) {
-    name = url.parse(name).pathname;
+    name = url.parse(name).path;
   }
 
   View.call(this, name, options);


### PR DESCRIPTION
Resolves #130 