### PR TITLE
3.0.0 query string fix

### DIFF
--- a/lib/expressView.js
+++ b/lib/expressView.js
@@ -32,7 +32,7 @@ function ReactEngineView(name, options) {
   this.useRouter = (name[0] === '/');
 
   if (this.useRouter) {
-    //name = url.parse(name).pathname;
+    name = url.parse(name).path;
   }
 
   View.call(this, name, options);

--- a/lib/expressView.js
+++ b/lib/expressView.js
@@ -32,7 +32,7 @@ function ReactEngineView(name, options) {
   this.useRouter = (name[0] === '/');
 
   if (this.useRouter) {
-    name = url.parse(name).pathname;
+    //name = url.parse(name).pathname;
   }
 
   View.call(this, name, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-engine",
-  "version": "3.0.0-query-string",
+  "version": "3.0.1",
   "description": "a composite render engine for express apps to render both plain react views and react-router views",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-engine",
-  "version": "3.0.0",
+  "version": "3.0.0-query-string",
   "description": "a composite render engine for express apps to render both plain react views and react-router views",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fix is a proposal for 3.0.1 which applies a fix from the 3.1.0 Express view to 3.0.0 where React Router does not receive the query string values.  3.0.0 does not work if you use query strings in your routes to change which component is displayed. This is a fix for issue #143 