### PR TITLE
Support ES6 module syntax for React views.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -192,6 +192,14 @@ exports.create = function create(createOptions) {
 
         var view = require(thing);
 
+        // Check for an ES6 `default` property on the module export
+        // ------------------------------------------------------------
+        // TypeScript and Babel users that leverage ES6 module depend on this
+        // e.g. `export default function MyView() {};`
+        if (view.default) {
+          view = view.default;
+        }
+
         // create the Component using react's createFactory
         var component = React.createFactory(view);
         return done(null, renderAndDecorate(component(data), data, html));


### PR DESCRIPTION
Check for `default` property on view export in `server.js`. This helps support TypeScript and Babel users that leverage ES6 modules and the `export default` syntax.

Note: tested and verified that both regular `module.exports = function () {}` as well as the new `export default function () {}` works as expected.