### PR TITLE
Added createOptions scriptLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Additionally, it can contain the following **optional** properties,
                    cases where [express's app property](http://expressjs.com/api.html#app.set) `view cache` is false, this way you don't need to restart the server every time a change is made in the view files or routes file.
 - `renderOptionsKeysToFilter`: \<Array> - an array of keys that need to be filtered out from the data object that gets fed into the react component for rendering. [more info](#data-for-component-rendering)
 - `performanceCollector`: \<Function> - to collects [perf stats](#performance-profiling)
+- `scriptLocation`: \<String> - where in the HTML you want the client data (i.e. `<script>var __REACT_ENGINE__ = ... </script>`) to be appended (_Default: `body`_).
+                    If the value is undefined or set to `body` the script is placed before the `</body>` tag.
+                    The only other value is `head` which appends the script before the `</head>` tag.
 
 ###### Rendering views on server side
 ```js

--- a/lib/server.js
+++ b/lib/server.js
@@ -121,7 +121,7 @@ exports.create = function create(createOptions) {
         html += script;
       }
       else {
-        var htmlTag = createOptions.scriptLoc === 'head' ? '</head>' : '</body>';
+        var htmlTag = createOptions.scriptLocation === 'head' ? '</head>' : '</body>';
         html = html.replace(htmlTag, script + htmlTag);
       }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -121,7 +121,8 @@ exports.create = function create(createOptions) {
         html += script;
       }
       else {
-        html = html.replace('</body>', script + '</body>');
+        var htmlTag = createOptions.scriptLoc === 'head' ? '</head>' : '</body>';
+        html = html.replace(htmlTag, script + htmlTag);
       }
 
       return html;


### PR DESCRIPTION
Adding a create option where the script, which contains __REACT_ENGINE__, can be added to the head of the html.  Ideally I would like an option to not automatically render the script tag automatically plus a function to generate the script which allows me to put it where I want in the html component manually, but this works for now.

--- Usage ---
const engine = reactEngine.server.create({
    routes: require('./routes.jsx'),
    routesFilePath: './routes.jsx',
    scriptLocation: 'head',
    page404: require('./not-found.jsx'))
  })