### PR TITLE
Fix #148: Update deprecated `history` and `RoutingContext` for react-router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .idea
 .project
 .settings
+*.swp
 logs
 *.log
 coverage/

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 
 ### Install
 ```sh
-# In your express app, react-engine needs to be installed along
-# side react and optionally react-router (+ history, react-router's dependency)
-npm install react-engine react react-router history --save
+# In your express app, react-engine needs to be installed alongside react (react-router is optional)
+$ npm install react-engine react@0.14 react-router --save
 ```
 
 ### Usage On Server Side

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,6 @@
 'use strict';
 
 var Config = require('./config.json');
-var createHistory = require('history').createHistory;
 var ReactDOM = require('react-dom');
 var merge = require('lodash/object/merge');
 
@@ -81,7 +80,7 @@ exports.boot = function boot(options, callback) {
       throw new Error('asking to use react router for rendering, but no routes are provided');
     }
 
-    history = options.history || browserHistory || createHistory();
+    history = options.history || browserHistory;
     location = _window.location.pathname +
       _window.location.search + _window.location.hash;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -52,11 +52,13 @@ exports.boot = function boot(options, callback) {
   var Router;
   var RouterComponent;
   var match;
+  var browserHistory;
 
   try {
     Router = require('react-router');
     RouterComponent = Router.Router;
     match = Router.match;
+    browserHistory = Router.browserHistory;
   } catch (err) {
     if (!Router && options.routes) {
       throw err;
@@ -79,7 +81,7 @@ exports.boot = function boot(options, callback) {
       throw new Error('asking to use react router for rendering, but no routes are provided');
     }
 
-    history = options.history || createHistory();
+    history = options.history || browserHistory || createHistory();
     location = _window.location.pathname +
       _window.location.search + _window.location.hash;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -55,12 +55,12 @@ exports.create = function create(createOptions) {
   var React = util.safeRequire('react');
   var Router;
   var match;
-  var RoutingContext;
+  var RouterContext;
 
   try {
     Router = require('react-router');
     match = Router.match;
-    RoutingContext = Router.RoutingContext;
+    RouterContext = Router.RouterContext;
   } catch (err) {
     if (!Router && createOptions.routes) {
       throw err;
@@ -175,7 +175,7 @@ exports.create = function create(createOptions) {
               return React.createElement(Component, merge({}, data, routerProps));
             };
 
-            return done(null, renderAndDecorate(React.createElement(RoutingContext, renderProps), data, html));
+            return done(null, renderAndDecorate(React.createElement(RouterContext, renderProps), data, html));
           } else {
             debug('server.js match 404');
             var err = generateReactRouterServerError(ReactRouterServerErrors.MATCH_NOT_FOUND);

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,6 +50,7 @@ function generateReactRouterServerError(type, existingErrorObj, additionalProper
 }
 
 exports.create = function create(createOptions) {
+  createOptions = createOptions || {};
 
   // safely require the peer-dependencies
   var React = util.safeRequire('react');
@@ -67,7 +68,6 @@ exports.create = function create(createOptions) {
     }
   }
 
-  createOptions = createOptions || {};
   createOptions.docType = isString(createOptions.docType) ? createOptions.docType : Config.docType;
   createOptions.renderOptionsKeysToFilter = createOptions.renderOptionsKeysToFilter || [];
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsdom": "3.0.0",
     "jshint": "^2.6.3",
     "react": "^0.14.0",
-    "react-router": "^1.0.3",
+    "react-router": "^2.4.0",
     "rewire": "^2.3.1",
     "sinon": "^1.14.1",
     "tape": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "debug": "^2.1.3",
     "glob": "^5.0.3",
-    "history": "^1.12.2",
     "lodash": "^3.10.1",
     "parent-require": "^1.0.0",
     "react-dom": "^0.14.0"


### PR DESCRIPTION
Resolves #148

#### Tasks:
- Rename react-router `RoutingContext` to `RouterContext`
- Use react-router's `browserHistory` instead of `history`
- Remove `history` from `lib/client.js` and `package.json`
- Bump `react-router` to `2.4.0`

#### Chore:
- Update `README.md` with removal of `history` and specify `react@0.14` since the latest is version `15.0.2`
- Make sure all tests pass
- Update `.gitignore` and ignore `*.swp` files