### PR TITLE
Support redux

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,8 @@
 var Config = require('./config.json');
 var ReactDOM = require('react-dom');
 var assign = require('lodash').assign;
+var Provider = require('react-redux').Provider;
+var isFunction = require('lodash').isFunction;
 
 // declaring like this helps in unit test
 // dependency injection using `rewire` module
@@ -76,6 +78,16 @@ exports.boot = function boot(options, callback) {
   var useRouter = (props.__meta.view === null);
   var mountNode = options.mountNode || _document;
 
+  // wrap component with react-redux Proivder if redux is required
+  var wrap = function(component) {
+    if (options.redux && options.redux.initStore && isFunction(options.redux.initStore)) {
+      var store = options.redux.initStore(props);
+      return React.createElement(Provider, { store: store }, component);
+    } else {
+      return component;
+    }
+  };
+
   if (useRouter) {
 
     if (!options.routes) {
@@ -101,7 +113,8 @@ exports.boot = function boot(options, callback) {
         history: history
       });
 
-      ReactDOM.render(routerComponent, mountNode);
+      // wrap routerComponent with redux provider
+      ReactDOM.render(wrap(routerComponent), mountNode);
     });
 
   } else {
@@ -114,7 +127,7 @@ exports.boot = function boot(options, callback) {
     // render the factory on the client
     // doing this, sets up the event
     // listeners and stuff aka mounting views.
-    ReactDOM.render(viewFactory(props), mountNode);
+    ReactDOM.render(wrap(viewFactory(props)), mountNode);
   }
 
   // call the callback with the data that was used for rendering

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,6 @@
 var Config = require('./config.json');
 var ReactDOM = require('react-dom');
 var assign = require('lodash').assign;
-var Provider = require('react-redux').Provider;
 var isFunction = require('lodash').isFunction;
 
 // declaring like this helps in unit test
@@ -81,6 +80,7 @@ exports.boot = function boot(options, callback) {
   // wrap component with react-redux Proivder if redux is required
   var wrap = function(component) {
     if (options.redux && options.redux.initStore && isFunction(options.redux.initStore)) {
+      var Provider = require('react-redux').Provider;
       var store = options.redux.initStore(props);
       return React.createElement(Provider, { store: store }, component);
     } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,8 +56,6 @@ exports.create = function create(createOptions) {
   var match;
   var RouterContext;
 
-  var Provider = require('react-redux').Provider;
-
   try {
     Router = require('react-router');
     match = Router.match;
@@ -112,6 +110,7 @@ exports.create = function create(createOptions) {
     function renderAndDecorate(component, data, html) {
       if (createOptions.redux && createOptions.redux.initStore) {
         // add redux provider
+        var Provider = require('react-redux').Provider;
         var initStore;
         try {
           initStore = require(createOptions.redux.initStore);

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,6 +56,8 @@ exports.create = function create(createOptions) {
   var match;
   var RouterContext;
 
+  var Provider = require('react-redux').Provider;
+
   try {
     Router = require('react-router');
     match = Router.match;
@@ -108,8 +110,22 @@ exports.create = function create(createOptions) {
     }
 
     function renderAndDecorate(component, data, html) {
-      // render the component
-      html += ReactDOMServer.renderToString(component);
+      if (createOptions.redux && createOptions.redux.initStore) {
+        // add redux provider
+        var initStore;
+        try {
+          initStore = require(createOptions.redux.initStore);
+          var store = initStore(data);
+          var wrappedComponent = React.createElement(Provider, { store: store }, component);
+          // render the component
+          html += ReactDOMServer.renderToString(wrappedComponent);
+        } catch (err) {
+          throw err;
+        }
+      } else {
+          // render the component
+        html += ReactDOMServer.renderToString(component);
+      }
 
       // state (script) injection
       var safeData = util.safeSciptTag(JSON.stringify(data));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "debug": "^2.1.3",
     "glob": "^7.0.5",
     "lodash": "^4.13.1",
-    "parent-require": "^1.0.0"
+    "parent-require": "^1.0.0",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2"
   },
   "devDependencies": {
     "babel-core": "^6.3.26",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "debug": "^2.1.3",
     "glob": "^7.0.5",
     "lodash": "^4.13.1",
-    "parent-require": "^1.0.0",
-    "react-redux": "^4.4.5",
-    "redux": "^3.5.2"
+    "parent-require": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.26",


### PR DESCRIPTION
This is to bring in `redux`/`react-redux` support: https://github.com/paypal/react-engine/issues/168

* Initial state: the data passed via `res.render` is set to be the `initial state` 

* Store creation: user provide a function through server`config` or client `option` to create a store. This function accepts `init state` and produces `store` (basically it is a curry function).

* Store binding: `react-redux` `Provider` is used to bind the `store` to the root element, which can be `react-router` component if `react-router` is used or a vanilla react component otherwise.

**Store initialization at client side**
Redux store create function `initStore` is passed to `react-engine.client` via boot `options`, which is invoked when wrap root component with `react-redux` Provider. The root component can be either `react-router` component or a vanilla `react` component.

*Example*
```javascript
var reducer;
...
client.boot({
  ...
  redux: {
    initStore: function(state) {
      return Redux.createStore(reducer, state);
    }
  }
});
```

**Store initialization at server side**
Similarly, a create function is needed to initialize the `redux` store. This function is provided through an optional config.
*Sample Kraken config*
```javascript
{
  ...
  "view engines": {
    "jsx": {
      "module": "react-engine/lib/server",
      "renderer": {
        "method": "create",
        "arguments": [
          {
            "routes": "require:./.build/routes/index.js",
            "redux": {
              "initStore": "path:./.build/store/init.js"
            }
          }
        ]
      }
    }
  }
 ...
}
```