### PR TITLE
support dot-lookup paths in renderOptionsKeysToFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,25 @@ It can contain the following properties,
 ### Data for component rendering
 The actual data that gets fed into the component for rendering is the `renderOptions` object that [express generates](https://github.com/strongloop/express/blob/2f8ac6726fa20ab5b4a05c112c886752868ac8ce/lib/application.js#L535-L588).
 
-If you don't want to pass all that data, you can pass in an array of object keys that react-engine can filter out from the `renderOptions` object before passing it into the component for rendering.
+If you don't want to pass all that data, you can pass in an array of object keys or dot-lookup paths that react-engine can filter out from the `renderOptions` object before passing it into the component for rendering.
 
 ```javascript
 // example of using `renderOptionsKeysToFilter` to filter `renderOptions` keys
 var engine = ReactEngine.server.create({
-  renderOptionsKeysToFilter: ['mySensitiveDataThatIsIn_res.locals'],
+  renderOptionsKeysToFilter: [
+    'mySensitiveData',
+    'somearrayAtIndex[3].deeply.nested'
+  ],
   routes: require(path.join(__dirname + './reactRoutes'))
 });
 ```
 
-Note: By default, the following three keys are always filtered out from `renderOptions` no matter whether `renderOptionsKeysToFilter` is configured or not.
-
-- `settings`
-- `enrouten`
-- `_locals`
+Notes:
+ - The strings `renderOptionsKeysToFilter` will be used with [lodash.unset](https://lodash.com/docs/#unset), so they can be either plain object keys for first-level properties of `renderOptions`, or dot-separated "lookup paths" as shown in the `lodash.unset` documentation. Use these lookup paths to filter out nested sub-properties.
+ - By default, the following three keys are always filtered out from `renderOptions` no matter whether `renderOptionsKeysToFilter` is configured or not.
+    - `settings`
+    - `enrouten`
+    - `_locals`
 
 ### Handling redirects and route not found errors on the server side
 While using react-router, it matches the url to a component based on the app's defined routes. react-engine captures the redirects and not-found cases that are encountered while trying to run the react-router's [match function on the server side](https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md).

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,6 +18,9 @@
 var isString = require('lodash/isString');
 var assign = require('lodash/assign');
 var omit = require('lodash/omit');
+var cloneDeepWith = require('lodash/cloneDeepWith');
+var forEach = require('lodash/forEach');
+var unset = require('lodash/unset');
 var path = require('path');
 var util = require('./util');
 var assert = require('assert');
@@ -114,7 +117,11 @@ exports.create = function create(createOptions) {
       html += ReactDOMServer.renderToString(component);
 
       // state (script) injection
-      var safeData = util.safeSciptTag(JSON.stringify(data));
+      var sanitized = cloneDeepWith(data);
+      forEach(createOptions.renderOptionsKeysToFilter, function(key) {
+        unset(sanitized, key);
+      });
+      var safeData = util.safeSciptTag(JSON.stringify(sanitized));
       var script = format(TEMPLATE, Config.client.markupId, safeData);
       if (createOptions.docType === '') {
         // if the `docType` is empty, the user did not want to add a docType to the rendered component,
@@ -151,7 +158,7 @@ exports.create = function create(createOptions) {
         view: null,
         markupId: Config.client.markupId
       }
-    }, omit(options, createOptions.renderOptionsKeysToFilter));
+    }, options);
     if (this.useRouter && !createOptions.routes) {
       return done(new Error('asking to use react router for rendering, but no routes are provided'));
     }


### PR DESCRIPTION
 - Change from using `_.omit` to [`_.unset`](https://lodash.com/docs#unset), so that a user can supply a set of path-lookup strings to be omitted, e.g.
    ```js
    renderOptionsKeysToFilter: ['context.pageInfo.debug', 'sys.pageInfo.debug']
    ```
    Since `_.unset` mutates the object, this change also clones it before serialization.

 - Change the usage site of `renderOptionsKeysToFilter` so it filters after server-side use, but before serialization.