### PR TITLE
Specify `react` and `react-dom` as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "sinon": "^1.14.1",
     "tape": "^4.6.0"
   },
+  "peerDependencies": {
+    "react": ">=0.14",
+    "react-dom": ">=0.14"
+  },
   "keywords": [
     "react",
     "render",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:paypal/react-engine.git"
+    "url": "https://github.com/paypal/react-engine"
+  },
+  "bugs": {
+    "url": "https://github.com/paypal/react-engine/issues"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Resolves #161

#### Chore:
- Specify `react` **>=0.14** and `react-dom` **>=0.14** as peerDependencies
- Add bugs field and update repository url in `package.json`