### PR TITLE
Update README instructions on client-side usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ res.render(req.url, data);
 
 ### Usage On Client Side (Mounting)
 ```js
-// assuming we use `browserify`
-var client = require('react-engine').client;
+// assuming we use a module bundler like `webpack` or `browserify`
+var client = require('react-engine/lib/client');
 
 // finally, boot whenever your app is ready
 // example:


### PR DESCRIPTION
Update instructions on client-side usage to require the specific client module. Otherwise, the entire package will be bundled in the build, which is unnecessary.

This follows the [example use case](https://github.com/paypal/react-engine/blob/master/example/public/index.js#L22).