### PR TITLE
ES6 support for redux store init method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -81,6 +81,9 @@ exports.boot = function boot(options, callback) {
   var wrap = function(component) {
     if (options.reduxStoreInitiator && isFunction(options.reduxStoreInitiator)) {
       var initStore = options.reduxStoreInitiator;
+      if (initStore.default) {
+        initStore = initStore.default;
+      }
       var store = initStore(props);
       var Provider = require('react-redux').Provider;
       return React.createElement(Provider, { store: store }, component);

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,6 +102,10 @@ exports.boot = function boot(options, callback) {
     location = _window.location.pathname +
       _window.location.search + _window.location.hash;
 
+    if (options.routes.default) {
+      options.routes = options.routes.default;
+    }
+
     // Wrap the 'render' function within a call to 'match'. This is a workaround to support
     // users using code splitting functionality
     match({ routes: options.routes, location: location }, function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -114,6 +114,9 @@ exports.create = function create(createOptions) {
         var initStore;
         try {
           initStore = require(createOptions.reduxStoreInitiator);
+          if (initStore.default) {
+            initStore = initStore.default;
+          }
           var store = initStore(data);
           var wrappedComponent = React.createElement(Provider, { store: store }, component);
           // render the component


### PR DESCRIPTION
This changes enable to write router.jsx and redux store in ES6.

an example of router.jsx
```js
export default (
    <Route path="/">
        <Route name=".." path="example/" component={..}> 
   </Route>
);
```

an example of redux store method 
```js
import { createStore, applyMiddleware, compose } from 'redux';
import thunkMiddleware from 'redux-thunk';

import rootReducer from '../reducer';

let createStoreWithMiddleware;

function isDevToolsInstalled() {
    return Boolean(typeof window !== 'undefined' && window.devToolsExtension);
}

const applyMiddlewareResponse = applyMiddleware(
    thunkMiddleware
);

if (process.env.NODE_ENV !== 'production') {
    createStoreWithMiddleware = compose(
        applyMiddlewareResponse,
        isDevToolsInstalled() ? window.devToolsExtension() : f => f
    )(createStore);
} else {
    createStoreWithMiddleware = applyMiddlewareResponse(createStore);
}

export default function configureStore(initialState) {
    return createStoreWithMiddleware(rootReducer, initialState);
};
```
Kraken config for `view engine`

```js
"view engines": {
    "jsx": {
      "module": "react-engine/lib/server",
      "renderer": {
        "method": "create",
        "arguments": [{
          "routesFilePath": "path:./.build/templates/routes.jsx",
          "routes": "path:./.build/templates/routes.jsx",
          "reduxStoreInitiator": "path:./.build/templates/store/configureStore.js"
        }]
      }
    }
  },
```

client side bootstrap configuration
```js

function runApp() {

    var Client = require('react-engine/lib/client');
    // boot options
    var options = {
        routes: require('../templates/routes.jsx'),
        reduxStoreInitiator: require('../templates/store/configureStore'),
        viewResolver: function(viewName) {
            return require('../templates/' + viewName);
        }
    };

    document.addEventListener('DOMContentLoaded', function onLoad() {
        Client.boot(options);
    });
}

runApp();
```
