### PR TITLE
Data script tag insertion doesn't use regex

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -136,7 +136,9 @@ exports.create = function create(createOptions) {
         }
         else {
           var htmlTag = createOptions.scriptLocation === 'head' ? '</head>' : '</body>';
-          html = html.replace(htmlTag, script + htmlTag);
+          var splitHtml = html.split(htmlTag);
+          splitHtml[0] += script;
+          html = splitHtml.join(htmlTag);
         }
       }
 


### PR DESCRIPTION
I was getting an invalid checksum error when rendering a page that contained a series of dollar signs ($$$). Since dollar signs are a special character in regex, every two dollar signs were being combined into a single escaped dollar sign (ex: $$$ -> $$).