### PR TITLE
Use lodash sub-module instead of main entrypoint

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,7 @@
 var Config = require('./config.json');
 var ReactDOM = require('react-dom');
 var assign = require('lodash/assign');
-var isFunction = require('lodash').isFunction;
+var isFunction = require('lodash/isFunction');
 
 // declaring like this helps in unit test
 // dependency injection using `rewire` module


### PR DESCRIPTION
React engine is usually used along with tools like webpack or browserify which usually produce smaller bundles out of the box when using lodash submodules instead of the main lodash entrypoint.

We just recently upgraded to use the latest react-engine version, which resulted in a bigger bundle for our applications because the whole lodash module is being imported. At least 40k (no gzip) were added because of this.