### PR TITLE
react-router moved to dependency of react engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "glob": "^7.0.5",
     "jsesc": "^2.2.0",
     "lodash": "^4.13.1",
-    "parent-require": "^1.0.0"
+    "parent-require": "^1.0.0",
+    "react-router": "^3.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.26",
@@ -43,7 +44,6 @@
     "jsdom": "^9.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-router": "^3.2.0",
     "rewire": "^2.3.1",
     "sinon": "^1.14.1",
     "tape": "^4.6.0"


### PR DESCRIPTION
Currently we need react-router as dependency in our repo even though we don't use react-router. figured we can just move it to be a dep of react-engine instead.